### PR TITLE
feat: Auto-copy transcript to clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0] - 2025-05-22
+
+### Added
+- Automatic copying of fetched transcripts to the system clipboard.
+- Added `--no-copy` command-line flag to disable the auto-copy feature.
+
+### Changed
+- Refactored code to use `pathlib` instead of `os.path` for improved path handling.
+
+
 ## [0.2.0] - 2025-05-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 dependencies = [
     "youtube-transcript-api~=1.0.3",
     "appdirs~=1.4.4",
+    "pyperclip~=1.8.2", # TODO: Check for latest version
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = [
     "youtube-transcript-api~=1.0.3",
     "appdirs~=1.4.4",
-    "pyperclip~=1.8.2", # TODO: Check for latest version
+    "pyperclip~=1.9.0",
 ]
 
 [project.scripts]

--- a/tests/test_ytt.py
+++ b/tests/test_ytt.py
@@ -2,15 +2,14 @@ import unittest
 from unittest.mock import patch, MagicMock
 import io # For capturing stderr/stdout
 import sys
-import os
+from pathlib import Path
 
 # Add project root to sys.path to allow importing ytt
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, project_root)
+project_root = Path(__file__).parent.parent.resolve()
+sys.path.insert(0, str(project_root))
 
-import ytt # Import the module under test
+import ytt
 
-# Make sure to import pyperclip if its exceptions are used directly in tests
 import pyperclip
 
 class TestYttClipboard(unittest.TestCase):
@@ -92,6 +91,6 @@ class TestYttClipboard(unittest.TestCase):
 
 if __name__ == '__main__':
     # Create tests directory if it doesn't exist
-    if not os.path.exists('tests'):
-        os.makedirs('tests')
+    if not Path('tests').exists():
+        Path('tests').mkdir()
     unittest.main()

--- a/tests/test_ytt.py
+++ b/tests/test_ytt.py
@@ -1,0 +1,97 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import io # For capturing stderr/stdout
+import sys
+import os
+
+# Add project root to sys.path to allow importing ytt
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, project_root)
+
+import ytt # Import the module under test
+
+# Make sure to import pyperclip if its exceptions are used directly in tests
+import pyperclip
+
+class TestYttClipboard(unittest.TestCase):
+
+    def setUp(self):
+        # Example transcript data
+        # Create mock objects that have a 'text' attribute
+        mock_line1 = MagicMock()
+        mock_line1.text = 'Hello world'
+        mock_line2 = MagicMock()
+        mock_line2.text = 'This is a test'
+        self.sample_transcript_data = [mock_line1, mock_line2]
+        self.expected_transcript_string = "Hello world\nThis is a test"
+
+    @patch('ytt.pyperclip.copy')
+    @patch('ytt.get_transcript') # Mock fetching the transcript
+    @patch('sys.stdout', new_callable=io.StringIO) # Capture stdout
+    @patch('ytt.load_config') # Mock loading config
+    @patch('ytt.extract_video_id') # Mock extracting video ID
+    def test_copy_successful(self, mock_extract_video_id, mock_load_config, mock_stdout, mock_get_transcript, mock_pyperclip_copy):
+        mock_extract_video_id.return_value = "test_video_id" # Dummy video ID
+        mock_get_transcript.return_value = self.sample_transcript_data
+        mock_load_config.return_value = {'preferred_languages': ['en']} # Mock config
+
+        # Simulate command line arguments for a fetch command
+        test_args = ['ytt.py', 'fetch', 'some_url']
+        with patch.object(sys, 'argv', test_args):
+            try:
+                ytt.main()
+            except SystemExit as e: # Catch sys.exit calls
+                self.assertEqual(e.code, None) # Or check for specific exit codes if expected
+
+        mock_pyperclip_copy.assert_called_once_with(self.expected_transcript_string)
+        self.assertIn(self.expected_transcript_string, mock_stdout.getvalue().replace('\\n', '\n'))
+
+
+    @patch('ytt.pyperclip.copy')
+    @patch('ytt.get_transcript')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('ytt.load_config')
+    @patch('ytt.extract_video_id')
+    def test_no_copy_flag(self, mock_extract_video_id, mock_load_config, mock_stdout, mock_get_transcript, mock_pyperclip_copy):
+        mock_extract_video_id.return_value = "test_video_id"
+        mock_get_transcript.return_value = self.sample_transcript_data
+        mock_load_config.return_value = {'preferred_languages': ['en']}
+
+        test_args = ['ytt.py', 'fetch', 'some_url', '--no-copy']
+        with patch.object(sys, 'argv', test_args):
+            try:
+                ytt.main()
+            except SystemExit as e:
+                self.assertEqual(e.code, None)
+
+        mock_pyperclip_copy.assert_not_called()
+        self.assertIn(self.expected_transcript_string, mock_stdout.getvalue().replace('\\n', '\n'))
+
+    @patch('ytt.pyperclip.copy', side_effect=pyperclip.PyperclipException("Mock clipboard error"))
+    @patch('ytt.get_transcript')
+    @patch('sys.stderr', new_callable=io.StringIO) # Capture stderr
+    @patch('sys.stdout', new_callable=io.StringIO) # Capture stdout
+    @patch('ytt.load_config')
+    @patch('ytt.extract_video_id')
+    def test_copy_fails_gracefully(self, mock_extract_video_id, mock_load_config, mock_stdout, mock_stderr, mock_get_transcript, mock_pyperclip_copy_fails):
+        mock_extract_video_id.return_value = "test_video_id"
+        mock_get_transcript.return_value = self.sample_transcript_data
+        mock_load_config.return_value = {'preferred_languages': ['en']}
+
+        test_args = ['ytt.py', 'fetch', 'some_url']
+        with patch.object(sys, 'argv', test_args):
+            try:
+                ytt.main()
+            except SystemExit as e:
+                self.assertEqual(e.code, None)
+        
+        mock_pyperclip_copy_fails.assert_called_once()
+        # The error message in ytt.py was updated to be more specific
+        self.assertIn("Warning: Could not copy to clipboard: Mock clipboard error", mock_stderr.getvalue())
+        self.assertIn(self.expected_transcript_string, mock_stdout.getvalue().replace('\\n', '\n'))
+
+if __name__ == '__main__':
+    # Create tests directory if it doesn't exist
+    if not os.path.exists('tests'):
+        os.makedirs('tests')
+    unittest.main()


### PR DESCRIPTION
Implements automatic copying of the fetched transcript to the system clipboard using the `pyperclip` library.

Key changes:
- Added `pyperclip` to project dependencies.
- Introduced a `--no-copy` command-line flag to disable the auto-copy feature. By default, copying is enabled.
- The transcript is copied as a single string with text segments joined by newline characters.
- Gracefully handles errors if clipboard utilities (e.g., `xclip`, `pbcopy`) are not available, printing a warning message to stderr.
- Added comprehensive unit tests for the new clipboard functionality, including tests for successful copy, the `--no-copy` flag, and error handling. These tests use `unittest.mock` to simulate clipboard operations and external dependencies.

The `print_transcript` function continues to output the transcript to stdout regardless of clipboard operations.