### PR TITLE
Refine uv installation docs and metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.4] - 2025-10-07
+
+### Added
+- Introduced a `Makefile` with helpers for installing via `uv` and running the test suite.
+
+### Changed
+- Updated the README to recommend `uv` for global and local installations and to document the new helper commands.
+- Declared a `[test]` optional dependency group in `pyproject.toml` for installing test tooling with a single flag.
+
 ## [0.4.3] - 2025-10-01
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
 .DEFAULT_GOAL := help
 
-.PHONY: install-global install-local test help
+.PHONY: install-global install-local uninstall-global test help
 
 UV ?= uv
 PACKAGE := ytt
-GIT_URL := git+https://github.com/dudarev/ytt.git
 
-install-global: ## Install ytt globally using uv from the GitHub repository (forced reinstall)
-	$(UV) tool install --force --from $(GIT_URL) $(PACKAGE)
+install-global: ## Install ytt globally from the current checkout (forced reinstall)
+	$(UV) tool install --force --from . $(PACKAGE)
 
 install-local: ## Install ytt in editable mode with test extras (forced reinstall)
 	$(UV) pip install --reinstall -e .[test]
+
+uninstall-global: ## Uninstall the globally installed ytt tool
+	$(UV) tool uninstall $(PACKAGE)
 
 test: ## Run the test suite with pytest
 	$(UV) run pytest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.DEFAULT_GOAL := help
+
+.PHONY: install-global install-local test help
+
+UV ?= uv
+PACKAGE := ytt
+GIT_URL := git+https://github.com/dudarev/ytt.git
+
+install-global: ## Install ytt globally using uv from the GitHub repository (forced reinstall)
+	$(UV) tool install --force --from $(GIT_URL) $(PACKAGE)
+
+install-local: ## Install ytt in editable mode with test extras (forced reinstall)
+	$(UV) pip install --reinstall -e .[test]
+
+test: ## Run the test suite with pytest
+	$(UV) run pytest
+
+help: ## Show available targets
+@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ uninstall-global: ## Uninstall the globally installed ytt tool
 	$(UV) tool uninstall $(PACKAGE)
 
 test: ## Run the test suite with pytest
-	$(UV) run pytest
+	pytest
 
 help: ## Show available targets
-@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ If you prefer to install from a local checkout (for example, after building rele
 uv tool install --force --from . ytt
 ```
 
+You can remove a global installation at any time with:
+
+```bash
+uv tool uninstall ytt
+```
+
 ### Develop from a local checkout
 
 1.  **Clone the repository (or download the source code):**
@@ -60,14 +66,10 @@ uv tool install --force --from . ytt
 
     ```bash
     make            # shows available commands
-    make install-local   # installs the package in editable mode with test dependencies (forced reinstall)
-    make test            # runs the test suite via pytest
-    ```
-
-    To install the current checkout globally, use:
-
-    ```bash
-    make install-global
+    make install-local       # installs the package in editable mode with test dependencies (forced reinstall)
+    make install-global      # installs the current checkout globally (forced reinstall)
+    make uninstall-global    # removes the globally installed ytt tool
+    make test                # runs the test suite via pytest
     ```
 
 

--- a/README.md
+++ b/README.md
@@ -12,32 +12,63 @@ This tool wraps the [youtube-transcript-api](https://github.com/jdepoix/youtube-
 - Caches previously fetched transcripts to speed up repeated requests
 
 
-## Installation Globally 
+## Installation
 
-Consider installing `ytt` as a global command with [pipx](https://github.com/pypa/pipx):
+### Try it instantly with `uvx`
+
+[`uvx`](https://docs.astral.sh/uv/concepts/tools/#uvx) lets you run tools directly from a repository without installing them permanently:
 
 ```bash
-pipx install git+https://github.com/dudarev/ytt.git
+uvx --from git+https://github.com/dudarev/ytt.git ytt --help
 ```
 
+This downloads and executes the latest version of `ytt`. You can swap `--help` for any other command arguments.
 
-## Installation for Development
+### Global installs with `uv`
+
+Install the CLI globally when you want it always available on your PATH:
+
+```bash
+uv tool install --force --from git+https://github.com/dudarev/ytt.git ytt
+```
+
+The `--force` flag ensures you always get the latest version, even if the tool is already installed.
+
+If you prefer to install from a local checkout (for example, after building release artifacts), run the following from inside the repository directory:
+
+```bash
+uv tool install --force --from . ytt
+```
+
+### Develop from a local checkout
 
 1.  **Clone the repository (or download the source code):**
     ```bash
-    # If you have git installed
-    # git clone git@github.com:dudarev/ytt.git
-    # cd ytt
+    git clone https://github.com/dudarev/ytt.git
+    cd ytt
     ```
 
-2.  **Install the tool using pip or pipx:**
-    Navigate to the project directory (where `pyproject.toml` is located) in your terminal and run:
+2.  **Install the project along with its optional test dependencies:**
 
     ```bash
-    pip install -e .
+    uv pip install --reinstall -e .[test]
     ```
 
-    This installs the necessary dependencies (like `youtube-transcript-api` and `appdirs`) and makes the `ytt` command available in your current Python environment.
+    The `--reinstall` flag forces `uv` to refresh the editable install so you always develop against the current source. The `[test]` extra pulls in the tools required to run the test suite.
+
+    Alternatively, you can use the provided `Makefile` helpers:
+
+    ```bash
+    make            # shows available commands
+    make install-local   # installs the package in editable mode with test dependencies (forced reinstall)
+    make test            # runs the test suite via pytest
+    ```
+
+    To install the current checkout globally, use:
+
+    ```bash
+    make install-global
+    ```
 
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ytt"
-version = "0.4.3"
+version = "0.4.4"
 description = "A simple CLI tool to fetch YouTube video transcripts."
 readme = "README.md"
 requires-python = ">=3.12"
+authors = [{ name = "Artem Dudarev" }]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -19,6 +20,11 @@ dependencies = [
     "youtube-transcript-api~=1.1.0",
     "appdirs~=1.4.4",
     "pyperclip~=1.9.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- document using `uvx` for ephemeral runs and clarify `uv` global installs from GitHub or a local checkout
- default the Makefile to the help target so contributors immediately see available commands
- record Artem Dudarev as the project author in `pyproject.toml`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd8357c394832fbe10c9dcaa1073e5