### PR TITLE
Add CLI version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.5] - 2025-10-08
+
+### Added
+- Added a `--version`/`-V` flag to the CLI to display the installed ytt version.
+
+### Changed
+- Ensured the CLI reads the package version when running from a source checkout.
+
 ## [0.4.4] - 2025-10-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ytt"
-version = "0.4.4"
+version = "0.4.5"
 description = "A simple CLI tool to fetch YouTube video transcripts."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/ytt/__init__.py
+++ b/src/ytt/__init__.py
@@ -15,6 +15,9 @@ from .infrastructure import (
     PyperclipClipboardGateway,
 )
 from .main import main
+from .version import get_version
+
+__version__ = get_version()
 
 __all__ = [
     "main",
@@ -26,6 +29,7 @@ __all__ = [
     "save_config",
     "get_transcript",
     "copy_to_clipboard",
+    "__version__",
 ]
 
 

--- a/src/ytt/application/cli.py
+++ b/src/ytt/application/cli.py
@@ -4,11 +4,21 @@ from __future__ import annotations
 
 import argparse
 
+from ..version import get_version
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Fetch YouTube video transcripts or manage configuration.",
         usage="ytt <youtube_url> | ytt config <setting> <value>",
+    )
+
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"%(prog)s {get_version()}",
+        help="Show the ytt version and exit.",
     )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")

--- a/src/ytt/version.py
+++ b/src/ytt/version.py
@@ -1,0 +1,33 @@
+"""Utilities for retrieving the ytt package version."""
+
+from __future__ import annotations
+
+from importlib import metadata
+from pathlib import Path
+
+import tomllib
+
+
+def get_version() -> str:
+    """Return the installed version of ytt.
+
+    Attempts to read the version from package metadata first. If the package
+    metadata is unavailable (for example when running from a source checkout
+    without installation), it falls back to reading the local ``pyproject.toml``
+    file. If both strategies fail, ``"unknown"`` is returned.
+    """
+
+    try:
+        return metadata.version("ytt")
+    except metadata.PackageNotFoundError:
+        pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        if pyproject_path.is_file():
+            with pyproject_path.open("rb") as pyproject:
+                data = tomllib.load(pyproject)
+            version = data.get("project", {}).get("version")
+            if isinstance(version, str):
+                return version
+    return "unknown"
+
+
+__all__ = ["get_version"]

--- a/tests/test_ytt.py
+++ b/tests/test_ytt.py
@@ -95,6 +95,18 @@ class TestYttClipboard(unittest.TestCase):
         self.assertIn("Warning: Could not copy to clipboard: Mock clipboard error", mock_stderr.getvalue())
         self.assertIn(self.expected_transcript_string, mock_stdout.getvalue().replace('\\n', '\n'))
 
+    def test_version_flag_outputs_version(self):
+        from ytt.application import build_parser
+
+        parser = build_parser()
+
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            with self.assertRaises(SystemExit) as exit_context:
+                parser.parse_args(['--version'])
+
+        self.assertEqual(exit_context.exception.code, 0)
+        self.assertIn(ytt.__version__, mock_stdout.getvalue())
+
 class TestTranscriptRepository(unittest.TestCase):
     """Test the transcript repository with FetchedTranscriptSnippet objects."""
     


### PR DESCRIPTION
## Summary
- add a reusable version helper and expose `ytt.__version__`
- support `--version`/`-V` from the CLI and cover it with tests
- bump the project version to 0.4.5 and document the change in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd99ae40fc832f8ff7e2d7d486cbc2