### PR TITLE
Add CLI metadata output and caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.2] - 2025-10-01
+
+### Fixed
+- Copy the same Markdown-formatted transcript, title, and description to the clipboard, honoring metadata display flags.
+
 ## [0.5.1] - 2025-10-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.0] - 2025-10-01
+
+### Added
+- Display the YouTube video title and description ahead of transcripts in the CLI with new opt-out flags for each field and all metadata.
+- Cache metadata alongside transcripts to reuse previously fetched titles and descriptions.
+
+### Changed
+- Introduced a metadata gateway and transcript bundle domain model so metadata and transcripts are fetched together.
+
 ## [0.4.5] - 2025-10-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1] - 2025-10-01
+
+### Changed
+- Render fetched transcripts in Markdown, including a level-one title, description section header, and transcript section header.
+
+### Fixed
+- Allow the `-V`/`--version` flag to work without requiring a subcommand so the CLI prints the version as expected.
+
 ## [0.5.0] - 2025-10-01
 
 ### Added

--- a/docs/plans/plan-001-add-title-and-description.md
+++ b/docs/plans/plan-001-add-title-and-description.md
@@ -1,6 +1,6 @@
 ---
 title: plan-001-add-title-and-description
-status: draft
+status: accepted
 owner: gpt-5-codex
 last-updated: 2025-10-01
 links: { prd: docs/prds/001-add-title-and-description.md, spec: docs/specs/spec-001-add-title-and-description.md, tasks: null, adrs: [] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ytt"
-version = "0.5.0"
+version = "0.5.1"
 description = "A simple CLI tool to fetch YouTube video transcripts."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ytt"
-version = "0.4.5"
+version = "0.5.0"
 description = "A simple CLI tool to fetch YouTube video transcripts."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ytt"
-version = "0.5.1"
+version = "0.5.2"
 description = "A simple CLI tool to fetch YouTube video transcripts."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/ytt/application/cli.py
+++ b/src/ytt/application/cli.py
@@ -33,6 +33,21 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Do not copy the transcript to the clipboard.",
     )
+    fetch_parser.add_argument(
+        "--no-title",
+        action="store_true",
+        help="Do not print the video title before the transcript.",
+    )
+    fetch_parser.add_argument(
+        "--no-description",
+        action="store_true",
+        help="Do not print the video description before the transcript.",
+    )
+    fetch_parser.add_argument(
+        "--no-metadata",
+        action="store_true",
+        help="Disable both title and description output.",
+    )
 
     config_parser = subparsers.add_parser("config", help="Configure ytt settings.")
     config_parser.add_argument(

--- a/src/ytt/application/fetch_service.py
+++ b/src/ytt/application/fetch_service.py
@@ -74,10 +74,14 @@ class FetchTranscriptUseCase:
             return
         metadata = bundle.metadata
         if show_title and metadata.title:
-            print(metadata.title)
+            print(f"# {metadata.title}")
             print()
         if show_description and metadata.description:
+            print("## Description")
+            print()
             print(metadata.description)
             print()
+        print("## Transcript")
+        print()
         for line in bundle.transcript:
             print(line.text)

--- a/src/ytt/domain/__init__.py
+++ b/src/ytt/domain/__init__.py
@@ -1,13 +1,16 @@
 """Domain layer for ytt."""
 
-from .entities import TranscriptLine
-from .services import TranscriptService, TranscriptRepository
+from .entities import TranscriptLine, VideoMetadata, VideoTranscriptBundle
+from .services import MetadataGateway, TranscriptRepository, TranscriptService
 from .value_objects import VideoID, extract_video_id
 
 __all__ = [
     "TranscriptLine",
+    "VideoMetadata",
+    "VideoTranscriptBundle",
     "TranscriptService",
     "TranscriptRepository",
+    "MetadataGateway",
     "VideoID",
     "extract_video_id",
 ]

--- a/src/ytt/domain/entities.py
+++ b/src/ytt/domain/entities.py
@@ -6,6 +6,22 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
+class VideoMetadata:
+    """Describes metadata associated with a YouTube video."""
+
+    title: str | None
+    description: str | None
+
+
+@dataclass(frozen=True)
+class VideoTranscriptBundle:
+    """Container that groups transcript lines with their metadata."""
+
+    transcript: list["TranscriptLine"]
+    metadata: VideoMetadata
+
+
+@dataclass(frozen=True)
 class TranscriptLine:
     """Represents a single line within a transcript."""
 

--- a/src/ytt/domain/services.py
+++ b/src/ytt/domain/services.py
@@ -5,15 +5,24 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, Protocol, Sequence
 
-from .entities import TranscriptLine
+from .entities import VideoMetadata, VideoTranscriptBundle
 from .value_objects import VideoID
 
 
 class TranscriptRepository(Protocol):
     """Port that retrieves transcripts for a video."""
 
-    def retrieve(self, video_id: VideoID, preferred_languages: Sequence[str]) -> Optional[list[TranscriptLine]]:
-        """Return a transcript for ``video_id`` or ``None`` if unavailable."""
+    def retrieve(
+        self, video_id: VideoID, preferred_languages: Sequence[str]
+    ) -> Optional[VideoTranscriptBundle]:
+        """Return transcript bundle for ``video_id`` or ``None`` if unavailable."""
+
+
+class MetadataGateway(Protocol):
+    """Port that resolves metadata for a video."""
+
+    def fetch(self, video_id: VideoID) -> VideoMetadata:
+        """Fetch metadata for ``video_id``."""
 
 
 @dataclass
@@ -22,8 +31,10 @@ class TranscriptService:
 
     repository: TranscriptRepository
 
-    def fetch(self, video_id: VideoID, preferred_languages: Sequence[str]) -> Optional[list[TranscriptLine]]:
-        """Fetch a transcript using the configured repository."""
+    def fetch(
+        self, video_id: VideoID, preferred_languages: Sequence[str]
+    ) -> Optional[VideoTranscriptBundle]:
+        """Fetch transcript bundle using the configured repository."""
 
         languages = list(preferred_languages)
         return self.repository.retrieve(video_id, languages)

--- a/src/ytt/infrastructure/__init__.py
+++ b/src/ytt/infrastructure/__init__.py
@@ -2,11 +2,13 @@
 
 from .config import ConfigRepository
 from .clipboard import ClipboardGateway, PyperclipClipboardGateway
+from .metadata import YouTubeMetadataGateway
 from .transcript_repository import CachedYouTubeTranscriptRepository
 
 __all__ = [
     "ConfigRepository",
     "ClipboardGateway",
     "PyperclipClipboardGateway",
+    "YouTubeMetadataGateway",
     "CachedYouTubeTranscriptRepository",
 ]

--- a/src/ytt/infrastructure/metadata.py
+++ b/src/ytt/infrastructure/metadata.py
@@ -1,0 +1,191 @@
+"""Infrastructure gateway for retrieving YouTube video metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from html import unescape
+from typing import Optional
+
+import requests
+from defusedxml import ElementTree as ET
+
+from ..domain.entities import VideoMetadata
+from ..domain.services import MetadataGateway
+from ..domain.value_objects import VideoID
+
+
+_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/126.0.0.0 Safari/537.36"
+)
+
+
+@dataclass
+class YouTubeMetadataGateway(MetadataGateway):
+    """Fetches video metadata by scraping the YouTube watch page."""
+
+    session: Optional[requests.Session] = None
+    timeout: float = 10.0
+
+    def __post_init__(self) -> None:
+        if self.session is None:
+            self.session = requests.Session()
+        self.session.headers.setdefault("User-Agent", _USER_AGENT)
+        self.session.headers.setdefault("Accept-Language", "en-US,en;q=0.9")
+
+    def fetch(self, video_id: VideoID) -> VideoMetadata:  # noqa: D401 - interface method
+        url = f"https://www.youtube.com/watch?v={video_id.value}"
+        try:
+            response = self.session.get(url, timeout=self.timeout)
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network defensive
+            print(f"Warning: Could not retrieve metadata for {video_id.value}: {exc}", file=sys.stderr)
+            return VideoMetadata(title=None, description=None)
+
+        html = response.text
+        player_response = self._extract_json_object(html, "ytInitialPlayerResponse")
+        initial_data = self._extract_json_object(html, "ytInitialData")
+        title = self._extract_title(player_response, html)
+        description = self._extract_description(player_response, initial_data, html)
+        return VideoMetadata(title=title, description=description)
+
+    # ------------------------------------------------------------------
+    # Extraction helpers
+    # ------------------------------------------------------------------
+    def _extract_json_object(self, html: str, marker: str) -> Optional[dict]:
+        marker_index = html.find(marker)
+        if marker_index == -1:
+            return None
+        brace_index = html.find("{", marker_index)
+        if brace_index == -1:
+            return None
+
+        depth = 0
+        for idx in range(brace_index, len(html)):
+            char = html[idx]
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    candidate = html[brace_index : idx + 1]
+                    try:
+                        return json.loads(candidate)
+                    except json.JSONDecodeError:
+                        return None
+        return None
+
+    def _extract_title(self, player_response: Optional[dict], html: str) -> Optional[str]:
+        title: Optional[str] = None
+        if isinstance(player_response, dict):
+            title = (
+                player_response.get("videoDetails", {}).get("title")
+                or player_response.get("microformat", {})
+                .get("playerMicroformatRenderer", {})
+                .get("title", {})
+                .get("simpleText")
+            )
+            if title:
+                return title.strip() or None
+
+        title = self._extract_open_graph(html, "og:title")
+        if title:
+            return title
+
+        match = re.search(r"<title>(.*?)</title>", html, flags=re.IGNORECASE | re.DOTALL)
+        if match:
+            value = unescape(match.group(1)).strip()
+            if value.lower().endswith("- youtube"):
+                value = value[:-9].rstrip()
+            return value or None
+        return None
+
+    def _extract_description(
+        self,
+        player_response: Optional[dict],
+        initial_data: Optional[dict],
+        html: str,
+    ) -> Optional[str]:
+        description: Optional[str] = None
+        if isinstance(player_response, dict):
+            video_details = player_response.get("videoDetails", {})
+            short_description = video_details.get("shortDescription")
+            if short_description:
+                description = short_description.strip()
+            if not description:
+                description = (
+                    player_response.get("microformat", {})
+                    .get("playerMicroformatRenderer", {})
+                    .get("description", {})
+                    .get("simpleText")
+                )
+                if isinstance(description, str):
+                    description = description.strip()
+        if description:
+            return description or None
+
+        description = self._extract_from_initial_data(initial_data)
+        if description:
+            return description
+
+        description = self._extract_open_graph(html, "og:description")
+        return description
+
+    def _extract_from_initial_data(self, data: Optional[dict]) -> Optional[str]:
+        if not isinstance(data, dict):
+            return None
+
+        # Walk a handful of observed locations that contain description runs.
+        engagement_panels = data.get("engagementPanels") or []
+        for panel in engagement_panels:
+            renderer = panel.get("engagementPanelSectionListRenderer")
+            if not isinstance(renderer, dict):
+                continue
+            content = renderer.get("content", {})
+            section_list_renderer = content.get("sectionListRenderer", {})
+            contents = section_list_renderer.get("contents", [])
+            for item in contents:
+                item_renderer = item.get("itemSectionRenderer", {})
+                for inner in item_renderer.get("contents", []):
+                    description_renderer = inner.get("videoDescriptionRenderer")
+                    if not isinstance(description_renderer, dict):
+                        continue
+                    runs = description_renderer.get("description", {}).get("runs", [])
+                    text = "".join(run.get("text", "") for run in runs if isinstance(run, dict))
+                    if text:
+                        return text.strip()
+        return None
+
+    def _extract_open_graph(self, html: str, property_name: str) -> Optional[str]:
+        head_match = re.search(r"<head.*?</head>", html, flags=re.IGNORECASE | re.DOTALL)
+        head_html = head_match.group(0) if head_match else html
+        fragment = f"<root>{head_html}</root>"
+        try:
+            root = ET.fromstring(fragment)
+        except ET.ParseError:
+            root = None
+
+        if root is not None:
+            for meta in root.iter("meta"):
+                prop = meta.get("property") or meta.get("name")
+                if prop and prop.lower() == property_name.lower():
+                    content = meta.get("content")
+                    if content:
+                        return unescape(content.strip()) or None
+
+        pattern = (
+            r"<meta[^>]+(?:property|name)=[\"']"
+            + re.escape(property_name)
+            + r"[\"'][^>]*content=[\"']([^\"']+)[\"']"
+        )
+        match = re.search(pattern, html, flags=re.IGNORECASE)
+        if match:
+            return unescape(match.group(1)).strip() or None
+        return None
+
+
+__all__ = ["YouTubeMetadataGateway"]

--- a/src/ytt/main.py
+++ b/src/ytt/main.py
@@ -54,13 +54,15 @@ def main() -> None:
             print(f"Error: Unknown config setting '{args.setting}'. Only 'languages' is supported.", file=sys.stderr)
             raise SystemExit(1)
     elif args.command == "fetch":
+        show_title = not (args.no_title or args.no_metadata)
+        show_description = not (args.no_description or args.no_metadata)
         bundle = fetch_use_case.execute(
             args.youtube_url,
             copy_to_clipboard=not args.no_copy,
+            show_title=show_title,
+            show_description=show_description,
         )
         if bundle:
-            show_title = not (args.no_title or args.no_metadata)
-            show_description = not (args.no_description or args.no_metadata)
             FetchTranscriptUseCase.render(
                 bundle,
                 show_title=show_title,

--- a/src/ytt/main.py
+++ b/src/ytt/main.py
@@ -17,12 +17,12 @@ from .infrastructure import (
 
 def _prepare_args(argv: List[str]):
     parser = build_parser()
-    if not argv or argv[0] not in {"fetch", "config"}:
-        if argv and ("http://" in argv[0] or "https://" in argv[0]):
+    if argv and argv[0] not in {"fetch", "config"}:
+        if "http://" in argv[0] or "https://" in argv[0]:
             argv = ["fetch", *argv]
-        else:
-            parser.print_help(sys.stderr)
-            raise SystemExit(1)
+    if not argv:
+        parser.print_help(sys.stderr)
+        raise SystemExit(1)
     return parser, parser.parse_args(argv)
 
 

--- a/tests/test_ytt.py
+++ b/tests/test_ytt.py
@@ -13,6 +13,7 @@ sys.path.insert(1, str(project_root))
 import ytt
 from ytt.domain import VideoID
 from ytt.domain.entities import TranscriptLine, VideoMetadata, VideoTranscriptBundle
+from ytt.application.fetch_service import FetchTranscriptUseCase
 
 import pyperclip
 
@@ -36,6 +37,28 @@ class TestYttClipboard(unittest.TestCase):
         self.expected_title_header = f"# {self.sample_metadata.title}"
         self.expected_description_header = "## Description"
         self.expected_transcript_header = "## Transcript"
+        self.expected_clipboard_full = "\n".join(
+            FetchTranscriptUseCase.render_lines(self.sample_bundle)
+        )
+        self.expected_clipboard_no_title = "\n".join(
+            FetchTranscriptUseCase.render_lines(
+                self.sample_bundle,
+                show_title=False,
+            )
+        )
+        self.expected_clipboard_no_description = "\n".join(
+            FetchTranscriptUseCase.render_lines(
+                self.sample_bundle,
+                show_description=False,
+            )
+        )
+        self.expected_clipboard_no_metadata = "\n".join(
+            FetchTranscriptUseCase.render_lines(
+                self.sample_bundle,
+                show_title=False,
+                show_description=False,
+            )
+        )
 
     @patch('ytt.pyperclip.copy')
     @patch('ytt.domain.services.TranscriptService.fetch') # Mock fetching the transcript
@@ -56,7 +79,7 @@ class TestYttClipboard(unittest.TestCase):
                 self.assertEqual(e.code, None) # Or check for specific exit codes if expected
 
         mock_fetch_transcript.assert_called_once()
-        mock_pyperclip_copy.assert_called_once_with(self.expected_transcript_string)
+        mock_pyperclip_copy.assert_called_once_with(self.expected_clipboard_full)
         stdout_value = mock_stdout.getvalue().replace('\\n', '\n')
         self.assertIn(self.expected_transcript_header, stdout_value)
         self.assertIn(self.expected_transcript_string, stdout_value)
@@ -109,7 +132,7 @@ class TestYttClipboard(unittest.TestCase):
                 self.assertIsNone(exc.code)
 
         mock_fetch_transcript.assert_called_once()
-        mock_pyperclip_copy.assert_called_once_with(self.expected_transcript_string)
+        mock_pyperclip_copy.assert_called_once_with(self.expected_clipboard_no_title)
         stdout_value = mock_stdout.getvalue().replace('\\n', '\n')
         self.assertIn(self.expected_transcript_header, stdout_value)
         self.assertIn(self.expected_transcript_string, stdout_value)
@@ -135,7 +158,7 @@ class TestYttClipboard(unittest.TestCase):
                 self.assertIsNone(exc.code)
 
         mock_fetch_transcript.assert_called_once()
-        mock_pyperclip_copy.assert_called_once_with(self.expected_transcript_string)
+        mock_pyperclip_copy.assert_called_once_with(self.expected_clipboard_no_description)
         stdout_value = mock_stdout.getvalue().replace('\\n', '\n')
         self.assertIn(self.expected_transcript_header, stdout_value)
         self.assertIn(self.expected_transcript_string, stdout_value)
@@ -161,7 +184,7 @@ class TestYttClipboard(unittest.TestCase):
                 self.assertIsNone(exc.code)
 
         mock_fetch_transcript.assert_called_once()
-        mock_pyperclip_copy.assert_called_once_with(self.expected_transcript_string)
+        mock_pyperclip_copy.assert_called_once_with(self.expected_clipboard_no_metadata)
         stdout_value = mock_stdout.getvalue().replace('\\n', '\n')
         self.assertIn(self.expected_transcript_header, stdout_value)
         self.assertIn(self.expected_transcript_string, stdout_value)

--- a/tests/test_ytt.py
+++ b/tests/test_ytt.py
@@ -1,6 +1,6 @@
 import unittest
-from unittest.mock import patch, MagicMock
-import io # For capturing stderr/stdout
+from unittest.mock import patch
+import io  # For capturing stderr/stdout
 import sys
 from pathlib import Path
 
@@ -12,6 +12,7 @@ sys.path.insert(1, str(project_root))
 
 import ytt
 from ytt.domain import VideoID
+from ytt.domain.entities import TranscriptLine, VideoMetadata, VideoTranscriptBundle
 
 import pyperclip
 
@@ -19,13 +20,19 @@ class TestYttClipboard(unittest.TestCase):
 
     def setUp(self):
         # Example transcript data
-        # Create mock objects that have a 'text' attribute
-        mock_line1 = MagicMock()
-        mock_line1.text = 'Hello world'
-        mock_line2 = MagicMock()
-        mock_line2.text = 'This is a test'
-        self.sample_transcript_data = [mock_line1, mock_line2]
+        self.sample_transcript_data = [
+            TranscriptLine(text="Hello world", start=0.0, duration=3.5),
+            TranscriptLine(text="This is a test", start=3.5, duration=2.1),
+        ]
         self.expected_transcript_string = "Hello world\nThis is a test"
+        self.sample_metadata = VideoMetadata(
+            title="Sample Title",
+            description="Sample Description",
+        )
+        self.sample_bundle = VideoTranscriptBundle(
+            transcript=self.sample_transcript_data,
+            metadata=self.sample_metadata,
+        )
 
     @patch('ytt.pyperclip.copy')
     @patch('ytt.domain.services.TranscriptService.fetch') # Mock fetching the transcript
@@ -34,7 +41,7 @@ class TestYttClipboard(unittest.TestCase):
     @patch('ytt.application.fetch_service.extract_video_id') # Mock extracting video ID
     def test_copy_successful(self, mock_extract_video_id, mock_get_languages, mock_stdout, mock_fetch_transcript, mock_pyperclip_copy):
         mock_extract_video_id.return_value = VideoID("test_video_id")
-        mock_fetch_transcript.return_value = self.sample_transcript_data
+        mock_fetch_transcript.return_value = self.sample_bundle
         mock_get_languages.return_value = ['en']
 
         # Simulate command line arguments for a fetch command
@@ -47,7 +54,10 @@ class TestYttClipboard(unittest.TestCase):
 
         mock_fetch_transcript.assert_called_once()
         mock_pyperclip_copy.assert_called_once_with(self.expected_transcript_string)
-        self.assertIn(self.expected_transcript_string, mock_stdout.getvalue().replace('\\n', '\n'))
+        stdout_value = mock_stdout.getvalue().replace('\\n', '\n')
+        self.assertIn(self.expected_transcript_string, stdout_value)
+        self.assertIn(self.sample_metadata.title, stdout_value)
+        self.assertIn(self.sample_metadata.description, stdout_value)
 
 
     @patch('ytt.pyperclip.copy')
@@ -57,7 +67,7 @@ class TestYttClipboard(unittest.TestCase):
     @patch('ytt.application.fetch_service.extract_video_id')
     def test_no_copy_flag(self, mock_extract_video_id, mock_get_languages, mock_stdout, mock_fetch_transcript, mock_pyperclip_copy):
         mock_extract_video_id.return_value = VideoID("test_video_id")
-        mock_fetch_transcript.return_value = self.sample_transcript_data
+        mock_fetch_transcript.return_value = self.sample_bundle
         mock_get_languages.return_value = ['en']
 
         test_args = ['ytt.py', 'fetch', 'some_url', '--no-copy']
@@ -69,7 +79,80 @@ class TestYttClipboard(unittest.TestCase):
 
         mock_fetch_transcript.assert_called_once()
         mock_pyperclip_copy.assert_not_called()
-        self.assertIn(self.expected_transcript_string, mock_stdout.getvalue().replace('\\n', '\n'))
+        stdout_value = mock_stdout.getvalue().replace('\\n', '\n')
+        self.assertIn(self.expected_transcript_string, stdout_value)
+        self.assertIn(self.sample_metadata.title, stdout_value)
+        self.assertIn(self.sample_metadata.description, stdout_value)
+
+    @patch('ytt.pyperclip.copy')
+    @patch('ytt.domain.services.TranscriptService.fetch')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('ytt.application.config_service.ConfigService.get_preferred_languages')
+    @patch('ytt.application.fetch_service.extract_video_id')
+    def test_no_title_flag(self, mock_extract_video_id, mock_get_languages, mock_stdout, mock_fetch_transcript, mock_pyperclip_copy):
+        mock_extract_video_id.return_value = VideoID("test_video_id")
+        mock_fetch_transcript.return_value = self.sample_bundle
+        mock_get_languages.return_value = ['en']
+
+        test_args = ['ytt.py', 'fetch', 'some_url', '--no-title']
+        with patch.object(sys, 'argv', test_args):
+            try:
+                ytt.main()
+            except SystemExit as exc:
+                self.assertIsNone(exc.code)
+
+        mock_fetch_transcript.assert_called_once()
+        mock_pyperclip_copy.assert_called_once_with(self.expected_transcript_string)
+        stdout_value = mock_stdout.getvalue().replace('\\n', '\n')
+        self.assertIn(self.sample_metadata.description, stdout_value)
+        self.assertNotIn(self.sample_metadata.title, stdout_value)
+
+    @patch('ytt.pyperclip.copy')
+    @patch('ytt.domain.services.TranscriptService.fetch')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('ytt.application.config_service.ConfigService.get_preferred_languages')
+    @patch('ytt.application.fetch_service.extract_video_id')
+    def test_no_description_flag(self, mock_extract_video_id, mock_get_languages, mock_stdout, mock_fetch_transcript, mock_pyperclip_copy):
+        mock_extract_video_id.return_value = VideoID("test_video_id")
+        mock_fetch_transcript.return_value = self.sample_bundle
+        mock_get_languages.return_value = ['en']
+
+        test_args = ['ytt.py', 'fetch', 'some_url', '--no-description']
+        with patch.object(sys, 'argv', test_args):
+            try:
+                ytt.main()
+            except SystemExit as exc:
+                self.assertIsNone(exc.code)
+
+        mock_fetch_transcript.assert_called_once()
+        mock_pyperclip_copy.assert_called_once_with(self.expected_transcript_string)
+        stdout_value = mock_stdout.getvalue().replace('\\n', '\n')
+        self.assertIn(self.sample_metadata.title, stdout_value)
+        self.assertNotIn(self.sample_metadata.description, stdout_value)
+
+    @patch('ytt.pyperclip.copy')
+    @patch('ytt.domain.services.TranscriptService.fetch')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('ytt.application.config_service.ConfigService.get_preferred_languages')
+    @patch('ytt.application.fetch_service.extract_video_id')
+    def test_no_metadata_flag(self, mock_extract_video_id, mock_get_languages, mock_stdout, mock_fetch_transcript, mock_pyperclip_copy):
+        mock_extract_video_id.return_value = VideoID("test_video_id")
+        mock_fetch_transcript.return_value = self.sample_bundle
+        mock_get_languages.return_value = ['en']
+
+        test_args = ['ytt.py', 'fetch', 'some_url', '--no-metadata']
+        with patch.object(sys, 'argv', test_args):
+            try:
+                ytt.main()
+            except SystemExit as exc:
+                self.assertIsNone(exc.code)
+
+        mock_fetch_transcript.assert_called_once()
+        mock_pyperclip_copy.assert_called_once_with(self.expected_transcript_string)
+        stdout_value = mock_stdout.getvalue().replace('\\n', '\n')
+        self.assertNotIn(self.sample_metadata.title, stdout_value)
+        self.assertNotIn(self.sample_metadata.description, stdout_value)
+        self.assertIn(self.expected_transcript_string, stdout_value)
 
     @patch('ytt.pyperclip.copy', side_effect=pyperclip.PyperclipException("Mock clipboard error"))
     @patch('ytt.domain.services.TranscriptService.fetch')
@@ -79,7 +162,7 @@ class TestYttClipboard(unittest.TestCase):
     @patch('ytt.application.fetch_service.extract_video_id')
     def test_copy_fails_gracefully(self, mock_extract_video_id, mock_get_languages, mock_stdout, mock_stderr, mock_fetch_transcript, mock_pyperclip_copy_fails):
         mock_extract_video_id.return_value = VideoID("test_video_id")
-        mock_fetch_transcript.return_value = self.sample_transcript_data
+        mock_fetch_transcript.return_value = self.sample_bundle
         mock_get_languages.return_value = ['en']
 
         test_args = ['ytt.py', 'fetch', 'some_url']
@@ -93,7 +176,10 @@ class TestYttClipboard(unittest.TestCase):
         mock_pyperclip_copy_fails.assert_called_once()
         # The error message in ytt.py was updated to be more specific
         self.assertIn("Warning: Could not copy to clipboard: Mock clipboard error", mock_stderr.getvalue())
-        self.assertIn(self.expected_transcript_string, mock_stdout.getvalue().replace('\\n', '\n'))
+        stdout_value = mock_stdout.getvalue().replace('\\n', '\n')
+        self.assertIn(self.expected_transcript_string, stdout_value)
+        self.assertIn(self.sample_metadata.title, stdout_value)
+        self.assertIn(self.sample_metadata.description, stdout_value)
 
     def test_version_flag_outputs_version(self):
         from ytt.application import build_parser


### PR DESCRIPTION
## Summary
- add metadata entities, gateway, and cache upgrades so transcript fetches persist titles and descriptions
- update the fetch use case, CLI flags, and main entrypoint to emit metadata ahead of transcript lines with opt-outs
- expand automated tests for metadata rendering and bump the release notes to version 0.5.0

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddaa5826fc832f90bbba1aacbe95d1